### PR TITLE
Fix/isolation geometry and numpad zoom

### DIFF
--- a/appGUI/MainGUI.py
+++ b/appGUI/MainGUI.py
@@ -3466,7 +3466,7 @@ class MainGUI(QtWidgets.QMainWindow):
                     self.app.on_flipy()
 
                 # Zoom In
-                if key == QtCore.Qt.Key.Key_Equal:
+                if key == QtCore.Qt.Key.Key_Equal or key == QtCore.Qt.Key.Key_Plus:
                     self.app.plotcanvas.zoom(1 / self.app.defaults['global_zoom_ratio'], self.app.mouse_pos)
 
                 # Zoom Out
@@ -3627,7 +3627,7 @@ class MainGUI(QtWidgets.QMainWindow):
                                              [self.app.geo_editor.snap_x, self.app.geo_editor.snap_y])
 
                 # Zoom In
-                if key == QtCore.Qt.Key.Key_Equal or key == '=':
+                if key == QtCore.Qt.Key.Key_Equal or key == QtCore.Qt.Key.Key_Plus or key == '=' or key == '+':
                     self.app.plotcanvas.zoom(self.app.defaults['global_zoom_ratio'],
                                              [self.app.geo_editor.snap_x, self.app.geo_editor.snap_y])
 
@@ -3867,7 +3867,7 @@ class MainGUI(QtWidgets.QMainWindow):
                                              [self.app.grb_editor.snap_x, self.app.grb_editor.snap_y])
                     return
 
-                if key == QtCore.Qt.Key.Key_Equal or key == '=':
+                if key == QtCore.Qt.Key.Key_Equal or key == QtCore.Qt.Key.Key_Plus or key == '=' or key == '+':
                     self.app.grb_editor.launched_from_shortcuts = True
                     self.app.plotcanvas.zoom(self.app.defaults['global_zoom_ratio'],
                                              [self.app.grb_editor.snap_x, self.app.grb_editor.snap_y])
@@ -4128,7 +4128,7 @@ class MainGUI(QtWidgets.QMainWindow):
                                              [self.app.exc_editor.snap_x, self.app.exc_editor.snap_y])
                     return
 
-                if key == QtCore.Qt.Key.Key_Equal or key == '=':
+                if key == QtCore.Qt.Key.Key_Equal or key == QtCore.Qt.Key.Key_Plus or key == '=' or key == '+':
                     self.app.exc_editor.launched_from_shortcuts = True
                     self.app.plotcanvas.zoom(self.app.defaults['global_zoom_ratio'],
                                              [self.app.exc_editor.snap_x, self.app.exc_editor.snap_y])

--- a/appPlugins/ToolIsolation.py
+++ b/appPlugins/ToolIsolation.py
@@ -3102,14 +3102,22 @@ class ToolIsolation(Gerber, AppTool):
             return 'fail'
 
         if isinstance(geom_shp, (MultiPolygon, MultiLineString)):
-            geom = geom_shp.geoms
+            geom_iter = geom_shp.geoms
+        else:
+            geom_iter = geom_shp
+
+        if isinstance(geom_shp, list):
+            # isolation_geometry() (and get_exteriors()/get_interiors()) return a plain
+            # list of BaseGeometry, not a Shapely Multi* geometry; wrap it into a single
+            # geometry object since the rest of this method (and its callers) expect one.
+            geom = unary_union(geom_shp)
         else:
             geom = geom_shp
 
         if invert:
             try:
                 pl = []
-                for p in geom:
+                for p in geom_iter:
                     if p is not None:
                         if isinstance(p, Polygon):
                             pl.append(Polygon(p.exterior.coords[::-1], p.interiors))
@@ -3117,12 +3125,12 @@ class ToolIsolation(Gerber, AppTool):
                             pl.append(Polygon(p.coords[::-1]))
                 geom = MultiPolygon(pl)
             except TypeError:
-                if isinstance(geom, Polygon) and geom is not None:
-                    geom = Polygon(geom.exterior.coords[::-1], geom.interiors)
-                elif isinstance(geom, LinearRing) and geom is not None:
-                    geom = Polygon(geom.coords[::-1])
+                if isinstance(geom_iter, Polygon) and geom_iter is not None:
+                    geom = Polygon(geom_iter.exterior.coords[::-1], geom_iter.interiors)
+                elif isinstance(geom_iter, LinearRing) and geom_iter is not None:
+                    geom = Polygon(geom_iter.coords[::-1])
                 else:
-                    msg = "ToolIsolation.generate_envelope() Error --> Unexpected Geometry %s" % type(geom)
+                    msg = "ToolIsolation.generate_envelope() Error --> Unexpected Geometry %s" % type(geom_iter)
                     self.app.log.debug(msg)
             except Exception as e:
                 self.app.log.error("ToolIsolation.generate_envelope() Error --> %s" % str(e))


### PR DESCRIPTION
Fixed a crash during isolation routing, added numpad keys + and - for zoom in / out since '=' does not work on a german keyboard